### PR TITLE
Removed SSL settings

### DIFF
--- a/tornado/route.py
+++ b/tornado/route.py
@@ -74,13 +74,8 @@ if __name__ == '__main__':
         'keyfile': os.path.join('cert/myserver.key')
         }
     """
-    ssl_options = {
-        'certfile': os.path.join(secrets.cert),
-        'keyfile': os.path.join(secrets.key)
-        }
-
     # Start HTTP Server
-    http_server = tornado.httpserver.HTTPServer(application, ssl_options = ssl_options)
+    http_server = tornado.httpserver.HTTPServer(application)
     http_server.listen(secrets.appPort)
 
     # Get a handle to the instance of IOLoop


### PR DESCRIPTION
This update will hopefully remove the SSL settings. This need checking and testing.

No need to do SSL internaly between Tornardo and NGNIX. 

This is a fix for. 
#23 

Can @MatsDahlberg  Check this and make a review comment and @viklund  to check and merge? 