### PR TITLE
Coverage thinning script

### DIFF
--- a/exac_browser/coverage-thinning.sh
+++ b/exac_browser/coverage-thinning.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+mkdir coverage-thinned
+
+for cov in coverage/Panel*.gz; do
+    printf 'Processing "%s"... ' "$cov" >&2
+
+    printf 'unzip... ' >&2
+    tmpcov="$( mktemp -p . )"
+    gzip -d -c "$cov" >"$tmpcov"
+
+    printf 'filter... ' >&2
+    head -n 1 "$tmpcov" >"$tmpcov".head
+    sed '1d' "$tmpcov" | awk '$2 % 10 == 0 { print }' >"$tmpcov".data
+
+    printf 'compress... ' >&2
+    cat "$tmpcov".head "$tmpcov".data | bgzip >coverage-thinned/"${cov##*/}"
+
+    printf 'index... ' >&2
+    tabix -f -s 1 -b 2 -e 2 coverage-thinned/"${cov##*/}"
+
+    printf 'done.\n' >&2
+    rm -f "$tmpcov" "$tmpcov".head "$tmpcov".data
+done

--- a/exac_browser/coverage-thinning.sh
+++ b/exac_browser/coverage-thinning.sh
@@ -2,7 +2,13 @@
 
 set -e
 
+if [[ ! -d "coverage" ]]; then
+    echo "Can not find directory 'coverage' here" >&2
+    exit 1
+fi
+
 mkdir coverage-thinned
+echo "Directory 'coverage-thinned' created" >&2
 
 for cov in coverage/Panel*.gz; do
     printf 'Processing "%s"... ' "$cov" >&2


### PR DESCRIPTION
The script to thin coverage added.

Will create a new set of coverage data consisting of only 10% of the original data (every 10th base).
Data is created in a new directory. The old data is untouched.