### PR TITLE
Disable download button once it's been clicked.

### DIFF
--- a/tornado/javascript/app.js
+++ b/tornado/javascript/app.js
@@ -168,6 +168,7 @@
     App.controller('downloadDataController', function($http, $scope) {
         this.lChecked = true;
         var localThis = this;
+        localThis.download_text = 'Download';
         localThis.data = gData;
         this.isChecked = function(){
             if(localThis.lChecked){
@@ -181,7 +182,9 @@
 
         this.downloadData = function(){
             $http.get('/logEvent/download').success(function(data){
-                console.log("Downloading")
+                localThis.lChecked = true;
+                console.log("Downloading");
+                localThis.download_text = 'Preparing';
             });
         };
     });

--- a/tornado/static/downloadData.html
+++ b/tornado/static/downloadData.html
@@ -91,7 +91,7 @@
 	 ng-class="{'disabled': downloadDataCtrl.lChecked}"
 	 download="swegen_20161223.tar"
 	 href="/release/swegen_20161223.tar"
-	 ng-click="downloadDataCtrl.downloadData()">Download</a>
+	 ng-click="downloadDataCtrl.downloadData()">{{downloadDataCtrl.download_text}}</a>
 
   </div>
   <div class="col-xs-2"></div>


### PR DESCRIPTION
This is a stopgap measure until we can get the download to start faster.