### PR TITLE
Safer backup of release

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -54,7 +54,7 @@ else
 fi
 
 # Use rsync to sync the "release" directory
-rsync --archive --no-perms \
+rsync --archive --ignore-existing --no-perms \
     --verbose --progress "$container_dir/" "$release_backups/"
 
 # Fix permissions and ownership on the whole /data/SweFreq directory


### PR DESCRIPTION
Use --ignore-existing to not modify already backed-up files.