### PR TITLE
Add linkhash table

### DIFF
--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -72,3 +72,17 @@ ALTER TABLE dataset_version ADD COLUMN
         var_call_ref    VARCHAR(50)     DEFAULT NULL;
 
 UPDATE dataset_version SET var_call_ref="hg19";
+
+-- Add the linkhash table
+
+CREATE TABLE IF NOT EXISTS linkhash (
+    linkhash_pk         INTEGER         NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    dataset_verison_pk  INTEGER         NOT NULL,
+    user_pk             INTEGER         NOT NULL,
+    hash                VARCHAR(64)     NOT NULL,
+    expires_ts          TIMESTAMP       NOT NULL,
+    CONSTRAINT FOREIGN KEY (dataset_version_pk)
+        REFERENCES dataset_version(dataset_version_pk),
+    CONSTRAINT FOREIGN KEY (user_pk) REFERENCES user(user_pk)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+

--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -86,3 +86,10 @@ CREATE TABLE IF NOT EXISTS linkhash (
     CONSTRAINT FOREIGN KEY (user_pk) REFERENCES user(user_pk)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+-- There's a new action ENUM in user_log too.
+
+ALTER TABLE user_log MODIFY COLUMN
+    action  ENUM ('consent','download',
+                  'access_requested','access_granted','access_revoked',
+                  'private_link')       DEFAULT NULL;
+

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -84,6 +84,17 @@ CREATE TABLE IF NOT EXISTS dataset_logo (
     CONSTRAINT FOREIGN KEY (dataset_pk) REFERENCES dataset(dataset_pk)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+CREATE TABLE IF NOT EXISTS linkhash (
+    linkhash_pk         INTEGER         NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    dataset_verison_pk  INTEGER         NOT NULL,
+    user_pk             INTEGER         NOT NULL,
+    hash                VARCHAR(64)     NOT NULL,
+    expires_ts          TIMESTAMP       NOT NULL,
+    CONSTRAINT FOREIGN KEY (dataset_version_pk)
+        REFERENCES dataset_version(dataset_version_pk),
+    CONSTRAINT FOREIGN KEY (user_pk) REFERENCES user(user_pk)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 -- Extra tables for dataset meta-data:
 
 CREATE TABLE IF NOT EXISTS study (

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -34,8 +34,8 @@ CREATE TABLE IF NOT EXISTS user_log (
     user_pk             INTEGER         NOT NULL,
     dataset_pk          INTEGER         NOT NULL,
     action  ENUM ('consent','download',
-                  'access_requested','access_granted','access_revoked')
-                                        DEFAULT NULL,
+                  'access_requested','access_granted','access_revoked',
+                  'private_link')       DEFAULT NULL,
     ts                  TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT FOREIGN KEY (user_pk)    REFERENCES user(user_pk),
     CONSTRAINT FOREIGN KEY (dataset_pk) REFERENCES dataset(dataset_pk)


### PR DESCRIPTION
The linkhash table provides a hash of at maximum 64 characters that is
connected with a dataset_version and a user.  Each entry has an expiry
timestamp.