### PR TITLE
Feature/schema update

### DIFF
--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -121,14 +121,14 @@ ALTER TABLE dataset_access
 CREATE OR REPLACE VIEW dataset_access_current AS
     SELECT DISTINCT
         access.*,
-        TRUE as has_access,
+        TRUE AS has_access,
         (consent.action IS NOT NULL) AS has_consented
     FROM dataset_access AS access
     LEFT JOIN user_log AS consent
         ON access.user_pk = consent.user_pk AND
            consent.action = 'consent'
     WHERE access.user_pk IN (
-    -- gets user_pk for all user with current access
+    -- gets user_pk for all users with current access
     -- from https://stackoverflow.com/a/39190423/4941495
     SELECT DISTINCT granted.user_pk FROM user_log granted
         LEFT JOIN user_log revoked

--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -103,7 +103,7 @@ ALTER TABLE dataset_version ADD COLUMN (
 
 ALTER TABLE dataset_version DROP COLUMN ts;
 
--- add the view
+-- add the dataset_version_current view
 
 CREATE OR REPLACE VIEW dataset_version_current AS
     SELECT * FROM dataset_version

--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -130,7 +130,7 @@ CREATE OR REPLACE VIEW dataset_access_current AS
     WHERE access.user_pk IN (
     -- gets user_pk for all users with current access
     -- from https://stackoverflow.com/a/39190423/4941495
-    SELECT DISTINCT granted.user_pk FROM user_log granted
+    SELECT granted.user_pk FROM user_log granted
         LEFT JOIN user_log revoked
                 ON granted.user_pk = revoked.user_pk AND
                    revoked.action  = 'access_revoked'
@@ -152,7 +152,7 @@ CREATE OR REPLACE VIEW dataset_access_waiting AS
            consent.action = 'consent'
     WHERE access.user_pk IN (
     -- get user_pk for all users that have pending access requests
-    SELECT DISTINCT requested.user_pk FROM user_log requested
+    SELECT requested.user_pk FROM user_log requested
         LEFT JOIN user_log granted
                 ON requested.user_pk = granted.user_pk AND
                    granted.action  = 'access_granted'

--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -150,17 +150,7 @@ CREATE OR REPLACE VIEW dataset_access_waiting AS
     LEFT JOIN user_log AS consent
         ON access.user_pk = consent.user_pk AND
            consent.action = 'consent'
-    WHERE access.user_pk NOT IN (
-    -- gets user_pk for all users with current access
-    -- from https://stackoverflow.com/a/39190423/4941495
-    SELECT DISTINCT granted.user_pk FROM user_log granted
-        LEFT JOIN user_log revoked
-                ON granted.user_pk = revoked.user_pk AND
-                   revoked.action  = 'access_revoked'
-        WHERE granted.action = 'access_granted' AND
-                (revoked.user_pk IS NULL OR granted.ts > revoked.ts)
-        GROUP BY granted.user_pk, granted.action
-    ) AND access.user_pk IN (
+    WHERE access.user_pk IN (
     -- get user_pk for all users that have pending access requests
     SELECT DISTINCT requested.user_pk FROM user_log requested
         LEFT JOIN user_log granted

--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -111,3 +111,31 @@ CREATE OR REPLACE VIEW dataset_version_current AS
         SELECT dataset_pk, MAX(dataset_version_pk) FROM dataset_version
         WHERE available_from < now()
         GROUP BY dataset_pk );
+
+-- add the dataset_access_current view
+
+ALTER TABLE dataset_access
+    DROP COLUMN has_consented,
+    DROP COLUMN has_access;
+
+CREATE OR REPLACE VIEW dataset_access_current AS
+    SELECT DISTINCT
+        access.*,
+        TRUE as has_access,
+        (consent.action IS NOT NULL) AS has_consented
+    FROM dataset_access AS access
+    LEFT JOIN user_log AS consent
+        ON access.user_pk = consent.user_pk AND
+           consent.action = 'consent'
+    WHERE access.user_pk IN (
+    -- gets user_pk for all user with current access
+    -- from https://stackoverflow.com/a/39190423/4941495
+    SELECT DISTINCT granted.user_pk FROM user_log granted
+        LEFT JOIN user_log revoked
+                ON granted.user_pk = revoked.user_pk AND
+                   revoked.action  = 'access_revoked'
+        WHERE granted.action = 'access_granted' AND
+                (revoked.user_pk IS NULL OR granted.ts > revoked.ts)
+        GROUP BY granted.user_pk, granted.action
+    );
+

--- a/sql/patch-master-db.sql
+++ b/sql/patch-master-db.sql
@@ -139,3 +139,35 @@ CREATE OR REPLACE VIEW dataset_access_current AS
         GROUP BY granted.user_pk, granted.action
     );
 
+-- add the dataset_access_waiting view
+
+CREATE OR REPLACE VIEW dataset_access_waiting AS
+    SELECT DISTINCT
+        access.*,
+        FALSE AS has_access,
+        (consent.action IS NOT NULL) AS has_consented
+    FROM dataset_access AS access
+    LEFT JOIN user_log AS consent
+        ON access.user_pk = consent.user_pk AND
+           consent.action = 'consent'
+    WHERE access.user_pk NOT IN (
+    -- gets user_pk for all users with current access
+    -- from https://stackoverflow.com/a/39190423/4941495
+    SELECT DISTINCT granted.user_pk FROM user_log granted
+        LEFT JOIN user_log revoked
+                ON granted.user_pk = revoked.user_pk AND
+                   revoked.action  = 'access_revoked'
+        WHERE granted.action = 'access_granted' AND
+                (revoked.user_pk IS NULL OR granted.ts > revoked.ts)
+        GROUP BY granted.user_pk, granted.action
+    ) AND access.user_pk IN (
+    -- get user_pk for all users that have pending access requests
+    SELECT DISTINCT requested.user_pk FROM user_log requested
+        LEFT JOIN user_log granted
+                ON requested.user_pk = granted.user_pk AND
+                   granted.action  = 'access_granted'
+        WHERE requested.action = 'access_requested' AND
+                (granted.user_pk IS NULL OR requested.ts > granted.ts)
+        GROUP BY requested.user_pk, requested.action
+    );
+

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -73,6 +73,36 @@ CREATE OR REPLACE VIEW dataset_access_current AS
         GROUP BY granted.user_pk, granted.action
     );
 
+CREATE OR REPLACE VIEW dataset_access_waiting AS
+    SELECT DISTINCT
+        access.*,
+        FALSE AS has_access,
+        (consent.action IS NOT NULL) AS has_consented
+    FROM dataset_access AS access
+    LEFT JOIN user_log AS consent
+        ON access.user_pk = consent.user_pk AND
+           consent.action = 'consent'
+    WHERE access.user_pk NOT IN (
+    -- gets user_pk for all users with current access
+    -- from https://stackoverflow.com/a/39190423/4941495
+    SELECT DISTINCT granted.user_pk FROM user_log granted
+        LEFT JOIN user_log revoked
+                ON granted.user_pk = revoked.user_pk AND
+                   revoked.action  = 'access_revoked'
+        WHERE granted.action = 'access_granted' AND
+                (revoked.user_pk IS NULL OR granted.ts > revoked.ts)
+        GROUP BY granted.user_pk, granted.action
+    ) AND access.user_pk IN (
+    -- get user_pk for all users that have pending access requests
+    SELECT DISTINCT requested.user_pk FROM user_log requested
+        LEFT JOIN user_log granted
+                ON requested.user_pk = granted.user_pk AND
+                   granted.action  = 'access_granted'
+        WHERE requested.action = 'access_requested' AND
+                (granted.user_pk IS NULL OR requested.ts > granted.ts)
+        GROUP BY requested.user_pk, requested.action
+    );
+
 CREATE TABLE IF NOT EXISTS dataset_version (
     dataset_version_pk  INTEGER         NOT NULL PRIMARY KEY AUTO_INCREMENT,
     dataset_pk          INTEGER         NOT NULL,

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS dataset_access (
     CONSTRAINT FOREIGN KEY (user_pk)    REFERENCES user(user_pk)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-CREATE OR REPLACE VIEW dataset_access_v AS
+CREATE OR REPLACE VIEW dataset_access_current AS
     SELECT DISTINCT
         access.*,
         TRUE as has_access,

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -64,7 +64,7 @@ CREATE OR REPLACE VIEW dataset_access_current AS
     WHERE access.user_pk IN (
     -- gets user_pk for all users with current access
     -- from https://stackoverflow.com/a/39190423/4941495
-    SELECT DISTINCT granted.user_pk FROM user_log granted
+    SELECT granted.user_pk FROM user_log granted
         LEFT JOIN user_log revoked
                 ON granted.user_pk = revoked.user_pk AND
                    revoked.action  = 'access_revoked'
@@ -84,7 +84,7 @@ CREATE OR REPLACE VIEW dataset_access_waiting AS
            consent.action = 'consent'
     WHERE access.user_pk IN (
     -- get user_pk for all users that have pending access requests
-    SELECT DISTINCT requested.user_pk FROM user_log requested
+    SELECT requested.user_pk FROM user_log requested
         LEFT JOIN user_log granted
                 ON requested.user_pk = granted.user_pk AND
                    granted.action  = 'access_granted'

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -55,14 +55,14 @@ CREATE TABLE IF NOT EXISTS dataset_access (
 CREATE OR REPLACE VIEW dataset_access_current AS
     SELECT DISTINCT
         access.*,
-        TRUE as has_access,
+        TRUE AS has_access,
         (consent.action IS NOT NULL) AS has_consented
     FROM dataset_access AS access
     LEFT JOIN user_log AS consent
         ON access.user_pk = consent.user_pk AND
            consent.action = 'consent'
     WHERE access.user_pk IN (
-    -- gets user_pk for all user with current access
+    -- gets user_pk for all users with current access
     -- from https://stackoverflow.com/a/39190423/4941495
     SELECT DISTINCT granted.user_pk FROM user_log granted
         LEFT JOIN user_log revoked

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -47,8 +47,6 @@ CREATE TABLE IF NOT EXISTS dataset_access (
     user_pk             INTEGER         NOT NULL,
     wants_newsletter    BOOLEAN         DEFAULT false,
     is_admin            BOOLEAN         DEFAULT false,
-    has_consented       BOOLEAN         DEFAULT false,
-    has_access          BOOLEAN         DEFAULT false,
     CONSTRAINT UNIQUE (dataset_pk, user_pk),
     CONSTRAINT FOREIGN KEY (dataset_pk) REFERENCES dataset(dataset_pk),
     CONSTRAINT FOREIGN KEY (user_pk)    REFERENCES user(user_pk)

--- a/sql/swefreq.sql
+++ b/sql/swefreq.sql
@@ -82,17 +82,7 @@ CREATE OR REPLACE VIEW dataset_access_waiting AS
     LEFT JOIN user_log AS consent
         ON access.user_pk = consent.user_pk AND
            consent.action = 'consent'
-    WHERE access.user_pk NOT IN (
-    -- gets user_pk for all users with current access
-    -- from https://stackoverflow.com/a/39190423/4941495
-    SELECT DISTINCT granted.user_pk FROM user_log granted
-        LEFT JOIN user_log revoked
-                ON granted.user_pk = revoked.user_pk AND
-                   revoked.action  = 'access_revoked'
-        WHERE granted.action = 'access_granted' AND
-                (revoked.user_pk IS NULL OR granted.ts > revoked.ts)
-        GROUP BY granted.user_pk, granted.action
-    ) AND access.user_pk IN (
+    WHERE access.user_pk IN (
     -- get user_pk for all users that have pending access requests
     SELECT DISTINCT requested.user_pk FROM user_log requested
         LEFT JOIN user_log granted


### PR DESCRIPTION
A fairly complicated view added. This PR also gets rid of both `has_access` and `has_consented` from `dataset_access`.

The view only contains users that has current access. It still has a `has_access` field, but its value is always true.