### PR TITLE
Fix for the remote IP logging problem

### DIFF
--- a/backend/route.py
+++ b/backend/route.py
@@ -119,10 +119,7 @@ if __name__ == '__main__':
 
     # Instantiate Application
     application = Application(tornado_settings)
-    application.listen(options.port)
-
-    # Start HTTP Server
-    http_server = tornado.httpserver.HTTPServer(application)
+    application.listen(options.port, xheaders=True)
 
     # Get a handle to the instance of IOLoop
     ioloop = tornado.ioloop.IOLoop.instance()


### PR DESCRIPTION
Tested in a local docker environment with an nginx reverse proxy.

Initially xheaders=True didn't seem to do anything, but after further reading I found that the http_server being created is actually not doing anything. Another http server is instead created using application.listen [1], and that's the one that needed the parameter.

[1] https://www.tornadoweb.org/en/stable/web.html#tornado.web.Application.listen