### PR TITLE
Fix error when checking is_admin

### DIFF
--- a/backend/application.py
+++ b/backend/application.py
@@ -575,6 +575,7 @@ class SFTPAccess(handlers.SafeHandler):
         """
         if db.get_admin_datasets(self.current_user).count() <= 0:
             self.finish({'user':None, 'expires':None, 'password':None})
+            return
 
         password = None
         username = None
@@ -600,6 +601,7 @@ class SFTPAccess(handlers.SafeHandler):
         """
         if db.get_admin_datasets(self.current_user).count() <= 0:
             self.finish({'user':None, 'expires':None, 'password':None})
+            return
 
         # Create a new password
         username = "_".join(self.current_user.name.split()) + "_sftp"

--- a/backend/application.py
+++ b/backend/application.py
@@ -105,6 +105,7 @@ class GetSchema(handlers.UnsafeHandler):
                     # If it's not available yet, only return if user is admin.
                     if not (self.current_user and self.current_user.is_admin(dataset_version.dataset)):
                         self.send_error(status_code=403)
+                        return
 
                 base_url = "%s://%s" % (self.request.protocol, self.request.host)
                 dataset_schema['url']         = base_url + "/dataset/" + dataset_version.dataset.short_name

--- a/backend/application.py
+++ b/backend/application.py
@@ -103,7 +103,7 @@ class GetSchema(handlers.UnsafeHandler):
 
                 if dataset_version.available_from > datetime.now():
                     # If it's not available yet, only return if user is admin.
-                    if not (self.current_user and self.current_user.is_admin(version.dataset)):
+                    if not (self.current_user and self.current_user.is_admin(dataset_version.dataset)):
                         self.send_error(status_code=403)
 
                 base_url = "%s://%s" % (self.request.protocol, self.request.host)


### PR DESCRIPTION
<!-- REMOVE SECTIONS THAT ARE NOT APPLICABLE, DON'T OVERTHINK IT -->

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
<!-- Describe your pull request in detail. -->
is_admin was raising an AttributeError as version was a string, and did thus not have the member dataset. It will now use the dataset_version object instead.
Fixing the problem also identified the problem that the function continued after send_error(), causing finish() to be called twice.
The same problem also occurs with calling finish inside (not at the end of) a function.

### Changes made:
<!-- Enumerate the changes with 1), 2), 3) etc. -->
<!-- Ensure the test cases are updated if needed. -->
1. version.dataset -> dataset_version.dataset
2. added return after send_error()
3. added return after finish() in two places