### PR TITLE
make sure the correct reference set is used for genes/transcripts

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -516,3 +516,19 @@ def build_dict_from_row(row):
             continue
         d[field] = value
     return d
+
+
+def get_reference_set_for_dataset(dataset):
+    """
+    Get the reference set associated with a dataset
+    Args:
+        dataset (str): short name of the dataset
+    Returns:
+        ReferenceSet: the associated reference set; returns None if not available
+    """
+    try:
+        return (Dataset.select()
+                .where(Dataset.short_name==dataset)
+                .get()).reference_set
+    except Dataset.DoesNotExist:
+        return None

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -281,9 +281,14 @@ class RawDataImporter(DataImporter):
         gq_mids = None
         with db.database.atomic():
             for filename in self.settings.variant_file:
-                # gene/transctipt dbids; need to add support for version
-                refgenes = {gene.gene_id: gene.id for gene in db.Gene.select(db.Gene.id, db.Gene.gene_id)}
-                reftranscripts = {tran.transcript_id: tran.id for tran in db.Transcript.select(db.Transcript.id, db.Transcript.transcript_id)}
+                ref_dbid = db.get_reference_dbid_dataset(self.settings.dataset)
+                refgenes = {gene.gene_id:gene.id for gene in (db.Gene.select(db.Gene.id, db.Gene.gene_id)
+                                                              .where(db.Gene.reference_set == ref_dbid))}
+                reftranscripts = {tran.transcript_id:tran.id for tran in (db.Transcript
+                                                                          .select(db.Transcript.id,
+                                                                                  db.Transcript.transcript_id)
+                                                                          .join(db.Gene)
+                                                                          .where(db.Gene.reference_set == ref_dbid))}
                 for line in self._open(filename):
                     line = bytes(line).decode('utf8').strip()
 

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -281,14 +281,14 @@ class RawDataImporter(DataImporter):
         gq_mids = None
         with db.database.atomic():
             for filename in self.settings.variant_file:
-                ref_dbid = db.get_reference_dbid_dataset(self.settings.dataset)
+                ref_set = get_reference_set_for_dataset(self.settings.dataset)
                 ref_genes = {gene.gene_id: gene.id for gene in (db.Gene.select(db.Gene.id, db.Gene.gene_id)
-                                                                .where(db.Gene.reference_set == ref_dbid))}
+                                                                .where(db.Gene.reference_set == ref_set))}
                 ref_transcripts = {tran.transcript_id: tran.id for tran in (db.Transcript
                                                                             .select(db.Transcript.id,
                                                                                     db.Transcript.transcript_id)
                                                                             .join(db.Gene)
-                                                                            .where(db.Gene.reference_set == ref_dbid))}
+                                                                            .where(db.Gene.reference_set == ref_set))}
                 for line in self._open(filename):
                     line = bytes(line).decode('utf8').strip()
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The current version of the vcf parser assumed there was only one reference set (or at least that the latest one should be used). Now the query will check for genes/transcripts from the correct reference set.