### PR TITLE
Feature/compute callcount

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -68,6 +68,7 @@ class ReferenceSet(BaseModel):
     ensembl_version = CharField()
     gencode_version = CharField()
     dbnsfp_version = CharField()
+    reference_build = CharField(unique=True)
 
 
 class Gene(BaseModel):
@@ -433,6 +434,17 @@ class Linkhash(BaseModel):
     user            = ForeignKeyField(User, related_name='link_hashes')
     hash            = CharField()
     expires_on      = DateTimeField()
+
+
+class BeaconCounts(BaseModel):
+    class Meta:
+        db_table = "beacon_dataset_counts_table"
+        schema = 'beacon'
+
+    datasetid    = CharField(primary_key=True)
+    callcount    = IntegerField()
+    variantcount = IntegerField()
+
 
 #####
 # Views

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -361,10 +361,12 @@ class RawDataImporter(DataImporter):
     def get_callcount(self, data):
         """Increment the call count by the calls found at this position."""
         if data['chrom'] == self.chrom and data['pos'] < self.lastpos:
-            # TODO check this earlier, to avoid partial data to be inserted in the DB
-            raise Exception(f"Variant file corrupt, variants not given in incremental order.")
+            # If this position is smaller than the last, the file order might be invalid.
+            # Give a warning, but keep on counting.
+            msg = "VCF file not ok, variants not given in incremental order. Callcount may not be valid!!!\n\n"
+            logging.warning(msg)
 
-        if data['chrom'] != self.chrom or data['pos'] > self.lastpos:
+        if data['chrom'] != self.chrom or data['pos'] != self.lastpos:
             # We are at a new position, count and save the calls for the last position
             self.counter['calls'] += len(self.counter['tmp_calls'])
 

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -101,11 +101,14 @@ class RawDataImporter(DataImporter):
         self.counter['calls'] += len(self.counter['tmp_calls'])
 
         ref_build = self.dataset_version.reference_set.reference_build
+        if not ref_build:
+            logging.warning('Reference build not set for dataset version.')
+            ref_build = ''  # avoid None
         datasetid = ':'.join([ref_build, self.dataset.short_name, self.dataset_version.version])
         datarow = {'datasetid': datasetid,
                    'callcount': self.counter['calls'],
                    'variantcount': self.counter['beaconvariants']}
-        logging.info('Dataset counts: %s', datarow)
+        logging.info('Dataset counts: callcount: %s, variantcount: %s', datarow['callcount'], datarow['variantcount'])
         if not self.settings.dry_run:
             db.BeaconCounts.insert(datarow).execute()
 

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -359,7 +359,7 @@ class RawDataImporter(DataImporter):
             logging.info("Inserted {} variant records in {}".format(counter, self._time_since(start)))
 
     def get_callcount(self, data):
-        """Increament the call count by the calls found at this position."""
+        """Increment the call count by the calls found at this position."""
         if data['chrom'] == self.chrom and data['pos'] < self.lastpos:
             # TODO check this earlier, to avoid partial data to be inserted in the DB
             raise Exception(f"Variant file corrupt, variants not given in incremental order.")

--- a/scripts/importer/importer.py
+++ b/scripts/importer/importer.py
@@ -91,6 +91,9 @@ if __name__ == '__main__':
     PARSER.add_argument("-q", "--quiet", action="count", default=0,
                         help="Decrease output Verbosity.")
 
+    PARSER.add_argument("--count_calls", action="store_true",
+                        help=("Count calls for the dataset (used by Beacon)"))
+
     # Beacon-only variants
     PARSER.add_argument("--beacon-only", action="store_true",
                         help=("Variants are intended only for Beacon, loosening"

--- a/sql/beacon_schema.sql
+++ b/sql/beacon_schema.sql
@@ -122,4 +122,5 @@ WHERE a.datasetId=b.datasetId;
 -- Indexes
 --
 CREATE INDEX beacon_data_chrpos ON data.variants ((substr(chrom, 1, 2)),(pos-1));
-CREATE INDEX beacon_data_chrref ON data.variants ((substr(chrom, 1, 2)),ref);
+-- Use if needed:
+-- CREATE INDEX beacon_data_chrref ON data.variants ((substr(chrom, 1, 2)),ref);

--- a/sql/beacon_schema.sql
+++ b/sql/beacon_schema.sql
@@ -52,7 +52,7 @@ CREATE OR REPLACE VIEW beacon.beacon_dataset_table AS           -- original type
 ;
 
 
-CREATE VIEW beacon.beacon_data_table AS
+CREATE OR REPLACE VIEW beacon.beacon_data_table AS
     SELECT dv.id AS index,                                      -- serial
            concat_ws(':', r.reference_build,
                           d.short_name,
@@ -82,9 +82,9 @@ CREATE VIEW beacon.beacon_data_table AS
 --------------------------------------------------------------------------------
 -- Beacon views.
 --
-CREATE VIEW beacon.dataset_metadata(name, datasetId, description, assemblyId,
-                                    createDateTime, updateDateTime, version,
-                                    callCount, variantCount, sampleCount, externalUrl, accessType)
+CREATE OR REPLACE VIEW beacon.dataset_metadata(name, datasetId, description, assemblyId,
+                                               createDateTime, updateDateTime, version,
+                                               callCount, variantCount, sampleCount, externalUrl, accessType)
 AS SELECT a.name, a.datasetId, a.description, a.assemblyId, a.createDateTime,
           a.updateDateTime, a.version, b.callCount,
           b.variantCount,

--- a/sql/beacon_schema.sql
+++ b/sql/beacon_schema.sql
@@ -79,32 +79,6 @@ CREATE VIEW beacon.beacon_data_table AS
 ;
 
 
-CREATE VIEW beacon.beacon_data_table AS
-    SELECT dv.id AS index,                                      -- serial
-           concat_ws(':', r.reference_build,
-                          d.short_name,
-                          v.dataset_version) AS datasetId,      -- varchar(128)
-           dv.pos AS "start",                                -- integer
-           substr(dv.chrom, 1, 2) AS chromosome,                -- varchar(2)
-           dv.ref AS reference,                                 -- varchar(8192)
-           dv.alt AS alternate,                                 -- varchar(8192)
-           dv.pos - 1 + char_length(dv.ref) AS "end",           -- integer
-           dv.allele_num AS callCount,                          -- integer
-           dv.allele_freq AS frequency,                         -- integer
-           dv.allele_count AS alleleCount,                      -- integer
-           CASE WHEN length(dv.ref) = length(dv.alt) THEN 'SNP'
-                WHEN length(dv.ref) > length(dv.alt) THEN 'DEL'
-                WHEN length(dv.ref) < length(dv.alt) THEN 'INS'
-           END AS variantType                                   -- varchar(16)
-     FROM data.variants AS dv
-      JOIN data.dataset_version_current as v
-        ON dv.dataset_version = v.id
-      JOIN data.datasets as d
-        ON v.dataset = d.id
-      JOIN data.reference_sets AS r
-        ON v.reference_set = r.id
-;
-
 --------------------------------------------------------------------------------
 -- Beacon views.
 --

--- a/sql/beacon_schema.sql
+++ b/sql/beacon_schema.sql
@@ -52,7 +52,7 @@ CREATE OR REPLACE VIEW beacon.beacon_dataset_table AS           -- original type
 ;
 
 
-CREATE MATERIALIZED VIEW beacon.beacon_data_table AS
+CREATE VIEW beacon.beacon_data_table AS
     SELECT dv.id AS index,                                      -- serial
            concat_ws(':', r.reference_build,
                           d.short_name,

--- a/sql/beacon_schema.sql
+++ b/sql/beacon_schema.sql
@@ -43,26 +43,11 @@ CREATE OR REPLACE VIEW beacon.beacon_dataset_table AS           -- original type
 ;
 
 
--- This seems to return correct values except that it seems to
--- _always_ return 1 for callCount, even when there's no data.
--- TODO: make sure that callCount can handle zero values.
-CREATE OR REPLACE VIEW beacon.beacon_dataset_counts_table AS
-    SELECT concat_ws(':', r.reference_build,
-                          d.short_name,
-                          v.dataset_version) AS datasetId,      -- varchar(128)
-           COUNT(DISTINCT(dv.chrom,
-                          dv.ref,
-                          dv.pos)) AS callCount,                -- integer
-           COUNT(dv)       AS variantCount                      -- integer
-      FROM data.datasets as d
-      JOIN data.dataset_version_current AS v
-        ON v.dataset = d.id
-      JOIN data.reference_sets AS r
-        ON v.reference_set = r.id
- LEFT JOIN data.variants AS dv
-        ON dv.dataset_version = v.id
-      GROUP BY r.reference_build, d.short_name, v.dataset_version
-;
+CREATE TABLE IF NOT EXISTS beacon.beacon_dataset_counts_table (
+    datasetid       varchar(128) PRIMARY KEY,
+    callCount       integer      DEFAULT NULL,
+    variantCount    integer      DEFAULT NULL
+);
 
 
 CREATE MATERIALIZED VIEW beacon.beacon_data_table AS
@@ -102,9 +87,9 @@ CREATE MATERIALIZED VIEW beacon.beacon_data_table AS
 -- CREATE UNIQUE INDEX metadata_conflict ON beacon_dataset_table (name, datasetId);
 -- This gets really, really slow if not materialized. (TODO why?)
 
-CREATE MATERIALIZED VIEW beacon.dataset_metadata(name, datasetId, description, assemblyId,
-                                        createDateTime, updateDateTime, version,
-                                        callCount, variantCount, sampleCount, externalUrl, accessType)
+CREATE VIEW beacon.dataset_metadata(name, datasetId, description, assemblyId,
+                                    createDateTime, updateDateTime, version,
+                                    callCount, variantCount, sampleCount, externalUrl, accessType)
 AS SELECT a.name, a.datasetId, a.description, a.assemblyId, a.createDateTime,
           a.updateDateTime, a.version, b.callCount,
           b.variantCount,


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [X] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Move the calculation of callcount from psql to python import (`--count_calls`) This speeds up queries to the beacon metadata, which no longer needs to be materialized.
Also improve the sql schema so that no views are materialized.


### Changes made:
1. Calculate the dataset's callcount and variantcount on import
2. Make `data_table` a real table
3. Stop materializing views
4. Add better indices


