### PR TITLE
Add empty category and flags field in case of empty VEP

### DIFF
--- a/backend/modules/browser/utils.py
+++ b/backend/modules/browser/utils.py
@@ -104,6 +104,9 @@ def add_consequence_to_variant(variant:dict):
         return
     worst_csq = worst_csq_with_vep(variant['vep_annotations'])
     variant['major_consequence'] = ''
+    variant['category'] = ''
+    variant['flags'] = ''
+
     if worst_csq is None:
         return
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
If VEP annotations are missing, the `flags` and `category` field will not be set correctly, leading to errors in the frontend. Thus empty definitions are added for the two fields.