### PR TITLE
Make beacon search specific, remove reference selection

### DIFF
--- a/frontend/src/js/controller.datasetBeaconController.js
+++ b/frontend/src/js/controller.datasetBeaconController.js
@@ -12,7 +12,7 @@
             Beacon.getBeaconReferences($routeParams.dataset, $routeParams.version)
 		.then(function(data) {
 		    if (data) {
-			localThis.references = data;
+			localThis.beaconInfo = data;
 		    }
                 });
 
@@ -33,7 +33,7 @@
         function search() {
             Beacon.queryBeacon(localThis)
                 .then(function(response) {
-		    if (!response.data.datasetAlleleResponses[0]) {
+		    if (response.data.exists===false) { // value may be null -> error
 			localThis.queryResponses.push({
                             "response": { "state": "Absent" },
                             "query": {
@@ -41,23 +41,32 @@
 				"position":        localThis.position,
 				"allele":          localThis.allele,
 				"referenceAllele": localThis.referenceAllele,
-				"reference":       localThis.reference
+                            }
+			});
+		    }
+		    else if (response.data.exists===true) {
+			localThis.queryResponses.push({
+			    "response": { "state": "Present" },
+			    "query": {
+				"chromosome":      localThis.chromosome,
+				"position":        localThis.position,
+				"allele":          localThis.allele,
+				"referenceAllele": localThis.referenceAllele,
                             }
 			});
 		    }
 		    else {
 			localThis.queryResponses.push({
-			    "response": { "state": "Present" },
-			    "query": {
-				"chromosome": response.data.datasetAlleleResponses[0].referenceName,
-				"position": response.data.datasetAlleleResponses[0].start + 1, // Beacon is 0-based
-				"allele": response.data.datasetAlleleResponses[0].alternateBases,
-				"referenceAllele": response.data.datasetAlleleResponses[0].referenceBases,
-				"reference": response.data.datasetAlleleResponses[0].datasetId.substring(0, 6),
-			    }
+                            "response": { "state": "Error" },
+                            "query": {
+				"chromosome":      localThis.chromosome,
+				"position":        localThis.position,
+				"allele":          localThis.allele,
+				"referenceAllele": localThis.referenceAllele,
+                            }
 			});
-		    }
-                },
+                    }
+		},
                 function() {
                     localThis.queryResponses.push({
                         "response": { "state": "Error" },
@@ -66,7 +75,6 @@
                             "position":        localThis.position,
                             "allele":          localThis.allele,
                             "referenceAllele": localThis.referenceAllele,
-                            "reference":       localThis.reference
                         }
                     });
                 }

--- a/frontend/src/js/controller.datasetBeaconController.js
+++ b/frontend/src/js/controller.datasetBeaconController.js
@@ -5,6 +5,7 @@
         var localThis = this;
         localThis.queryResponses = [];
         localThis.search = search;
+        localThis.fillExample = fillExample;
 
         activate();
 
@@ -80,5 +81,11 @@
                 }
             );
         }
+	function fillExample() {
+	    localThis.chromosome = "22";
+	    localThis.position = 46615880;
+	    localThis.referenceAllele = "T";
+	    localThis.allele = "C";
+	}
     }]);
 })();

--- a/frontend/src/js/factory.beacon.js
+++ b/frontend/src/js/factory.beacon.js
@@ -14,7 +14,10 @@
                     for (var i = 0; i < d.length; i++) {
 			var dataset = d[i].id;
 			if (dataset.indexOf(name) != -1 && dataset.indexOf(version) != -1) {
-			    return [dataset.split(":")[0].substring(0, 6)];
+			    return {
+				"reference": dataset.split(":")[0].substring(0, 6),
+				"datasetId": dataset,
+			    }
 			}
                     }
 		}
@@ -22,20 +25,24 @@
 		    var references = [];
 		    for (var i = 0; i < d.length; i++) {
 			var dataset = d[i].id;
-			if (dataset.indexOf(name) != -1) {
+			if (dataset.indexOf(name) !== -1) {
 			    references.push(dataset);
 			}
                     }
 		    var highest_ver = 0;
 		    var reference = "";
 		    for (var i = 0; i < references.length; i++) {
-			var ver = parseInt(dataset.split(":")[2]);
+			var ver = parseInt(references[i].split(":")[2]);
 			if (ver > highest_ver) {
 			    highest_ver = ver;
-			    reference = dataset.split(":")[0].substring(0, 6);
+			    reference = references[i].split(":")[0].substring(0, 6);
+			    beaconId = references[i];
 			}
 		    }
-		    return [reference]
+		    return {
+			"reference": reference,
+			"datasetId": beaconId,
+		    }
 		}
             });
         }
@@ -47,9 +54,8 @@
                         "start":           query.position - 1, // Beacon is 0-based
                         "alternateBases":  query.allele,
                         "referenceBases":  query.referenceAllele,
-                        "datasetIds":      query.dataset.shortName,
-                        "assemblyId":      query.reference,
-			"includeDatasetResponses": "HIT"
+                        "datasetIds":      query.beaconInfo.datasetId,
+                        "assemblyId":      query.beaconInfo.reference,
                     }
                 }
             );

--- a/frontend/templates/ng-templates/dataset-beacon.html
+++ b/frontend/templates/ng-templates/dataset-beacon.html
@@ -46,6 +46,8 @@
         Help
       </a>
     </div>
+    <div class="col-sm-2">
+      <a style='cursor: pointer' ng-click="ctrl.fillExample()" class="pull-right">Show example</a>
   </div>
 </form>
 <div class="row" ng-show="showDetails">

--- a/frontend/templates/ng-templates/dataset-beacon.html
+++ b/frontend/templates/ng-templates/dataset-beacon.html
@@ -3,7 +3,7 @@
 [% block controller %]datasetBeaconController[% endblock %]
 [% block contents %]
 <h2>Search</h2>
-<div class="alert alert-danger" ng-if="!ctrl.references[0]">
+<div class="alert alert-danger" ng-if="!ctrl.beaconInfo.reference">
   <h3>Beacon error</h3>
   <p>Unable to retrieve the reference set from the Beacon.</p>
   <p>Either the dataset version is not available or the service is down.</p>
@@ -13,37 +13,31 @@
   <div class="form-group">
     <label for="chromosome" class="col-sm-3 control-label">Chromosome</label>
     <div class="col-sm-3">
-      <input type="text" required ng-pattern='/^([1-9]|1[0-9]|2[0-2]|X|Y|x|y)$/' class="form-control" id="chromosome" name="chromosome" ng-model="ctrl.chromosome" placeholder="Chromosome" ng-disabled="!ctrl.references[0]">
+      <input type="text" required ng-pattern='/^([1-9]|1[0-9]|2[0-2]|X|Y|x|y)$/' class="form-control" id="chromosome" name="chromosome" ng-model="ctrl.chromosome" placeholder="Chromosome" ng-disabled="!ctrl.beaconInfo.reference">
     </div>
 
     <label for="position" class="col-sm-3 control-label">Position</label>
     <div class="col-sm-3">
-      <input type="number" required class="form-control" id="position" ng-model="ctrl.position" placeholder="Position" ng-disabled="!ctrl.references[0]">
+      <input type="number" required class="form-control" id="position" ng-model="ctrl.position" placeholder="Position" ng-disabled="!ctrl.beaconInfo.reference">
     </div>
   </div>
 
   <div class="form-group">
     <label for="referenceAllele" class="col-sm-3 control-label">Reference Allele</label>
     <div class="col-sm-3">
-      <input type="text" required ng-pattern='/^([ATCGatcg]+)$/' class="form-control" id="referenceAllele" ng-model="ctrl.referenceAllele" name='referenceAllele' placeholder="Reference Allele" ng-disabled="!ctrl.references[0]">
+      <input type="text" required ng-pattern='/^([ATCGatcg]+)$/' class="form-control" id="referenceAllele" ng-model="ctrl.referenceAllele" name='referenceAllele' placeholder="Reference Allele" ng-disabled="!ctrl.beaconInfo.reference">
     </div>
     
     <label for="allele" class="col-sm-3 control-label">Alternate Allele</label>
     <div class="col-sm-3">
-      <input type="text" required ng-pattern='/^([ATCGatcg]+)$/' class="form-control" id="allele" ng-model="ctrl.allele" name='allele' placeholder="Alternate Allele" ng-disabled="!ctrl.references[0]">
-    </div>
-  </div>
-
-  <div class="form-group">
-    <label for="reference" class="col-sm-3 control-label">Reference</label>
-    <div class="col-sm-3">
-      <select required class="form-control" ng-disabled="!ctrl.references[0]" ng-model="ctrl.reference" ng-options="r as r for r in ctrl.references"></select>
+      <input type="text" required ng-pattern='/^([ATCGatcg]+)$/' class="form-control" id="allele" ng-model="ctrl.allele" name='allele' placeholder="Alternate Allele" ng-disabled="!ctrl.beaconInfo.reference">
     </div>
   </div>
 
   <div class="form-group">
     <div class="col-sm-offset-3 col-sm-7">
-      <button ng-click="ctrl.search()" class="btn btn-primary" ng-disabled="!(ctrl.chromosome && ctrl.position && ctrl.referenceAllele && ctrl.allele && ctrl.reference)">Search</button><span class="left-margin alert-text" ng-if="!(ctrl.chromosome && ctrl.position && ctrl.referenceAllele && ctrl.allele && ctrl.reference)">Need to fill in all values before searching</span>
+      <button ng-click="ctrl.search()" class="btn btn-primary" ng-disabled="!(ctrl.chromosome && ctrl.position && ctrl.referenceAllele && ctrl.allele && ctrl.beaconInfo.reference)">Search</button>
+      <span class="left-margin alert-text" ng-if="!(ctrl.chromosome && ctrl.position && ctrl.referenceAllele && ctrl.allele) && ctrl.beaconInfo.reference">Need to fill in all values before searching</span>
     </div>
     <div class="col-sm-2">
       <a style='cursor: pointer' ng-click="showDetails = ! showDetails" class="pull-right">
@@ -75,7 +69,6 @@
       <th>Position</th>
       <th>Reference Allele</th>
       <th>Alternate Allele</th>
-      <th>Reference</th>
     </tr>
     <tr ng-repeat="row in ctrl.queryResponses">
       <td>{{row.response.state}}</td>
@@ -83,7 +76,6 @@
       <td>{{row.query.position}}</td>
       <td>{{row.query.referenceAllele}}</td>
       <td>{{row.query.allele}}</td>
-      <td>{{row.query.reference}}</td>
     </tr>
   </table>
 </div>


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The earlier version used the wrong datasetID for searches. The Beacon system currently interprets incorrect datasetIDs as "search in all datasets", ie the old search checked all datasets. An example 
is `4-100118858-C-T` - earlier both ACpop and SweGen reported it as `present`, now it is (correctly) `absent` in ACpop.

The reference selection is also removed from the frontend. It would always contain only one choice (the reference used by the dataset), and led to a `<select>` element with only one value available.

Finally, a "show example" text has been added, which fills the form with the variant `22-46615880-T-C`, which is also used in the browser.

### Changes made:
* The datasetID is now taken from Beacon, allowing correct searches.
* Reference selection is removed from the frontend.
* "Show example" "button" added.