### PR TITLE
Fix sFTP for Postgres

### DIFF
--- a/backend/application.py
+++ b/backend/application.py
@@ -632,10 +632,12 @@ class SFTPAccess(handlers.SafeHandler):
         expires = datetime.today() + timedelta(days=30)
 
         # Check if an sFTP user exists for the current user when the database is ready
+        passwd_hash = fn.encode(fn.digest(password, 'sha256'), 'hex')
+
         try:
             self.current_user.sftp_user.get()
             # if we have a user, update it
-            db.SFTPUser.update(password_hash = fn.SHA2(password, 256),
+            db.SFTPUser.update(password_hash = passwd_hash,
                                account_expires = expires
                                ).where(db.SFTPUser.user == self.current_user).execute()
         except db.SFTPUser.DoesNotExist:
@@ -643,7 +645,7 @@ class SFTPAccess(handlers.SafeHandler):
             db.SFTPUser.insert(user = self.current_user,
                                user_uid = db.get_next_free_uid(),
                                user_name = username,
-                               password_hash = fn.SHA2(password, 256),
+                               password_hash = passwd_hash,
                                account_expires = expires
                                ).execute()
 

--- a/frontend/templates/ng-templates/dataset-admin.html
+++ b/frontend/templates/ng-templates/dataset-admin.html
@@ -13,7 +13,6 @@
                 <ul class="nav nav-tabs pull-right">
                     <li class="active"><a data-target="#pending" data-toggle="tab">Pending requests</a></li>
                     <li><a data-target="#approved" data-toggle="tab">Approved users</a></li>
-                    <li><a data-target="#sftp" data-toggle="tab">sFTP Access</a></li>
                     <li><a data-target="#emaillist" data-toggle="tab">Email list</a></li>
                 </ul>
             </div>
@@ -70,40 +69,6 @@
                         <td>{{row.applyDate}}</td>
                     </tr>
                 </table>
-            </div>
-        </div>
-
-        <div class="tab-pane" id="sftp">
-            <div class="col-sm-6 center-block" style="float:none">
-                <h3>sFTP Credentials</h3>
-                <div class="form-horizontal">
-                    <div class="form-group">
-                        <label for="sftp-user" class="col-sm-4 control-label">Username</label>
-                        <div class="col-sm-8">
-                            <input id="sftp-user" type="text" class="form-control" value="{{ ctrl.sftp.user }}" readonly>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="sftp-pass" class="col-sm-4 control-label">Password</label>
-                        <div class="col-sm-8">
-                            <input id="sftp-pass" type="text" class="form-control" value="{{ ctrl.sftp.password }}" readonly>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="sftp-expiry" class="col-sm-4 control-label">Expiry date</label>
-                        <div class="col-sm-8">
-                            <input id="sftp-expiry" type="text" class="form-control" value="{{ ctrl.sftp.expires }}" readonly>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <div class="col-sm-8 col-sm-offset-4">
-                            <button type="button" ng-click="ctrl.createSFTPCredentials()" class="btn btn-primary form-control">Generate Credentials</button>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
 


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Updated the generate sFTP credentials functions to use `digest()` instead of `SHA2`, including a workaround to remove the prefix `'\x'` from the generated hash.

Also removes the non-functional sFTP tab from the dataset admin page.