### PR TITLE
Updates to the beacon breakends

### DIFF
--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -199,7 +199,7 @@ class RawDataImporter(DataImporter):
                     continue
 
                 if base["chrom"].startswith('GL') or base["chrom"].startswith('MT'):
-                    # A BND from GL or MT.
+                    # A BND from GL or MT. GL is an unplaced scaffold, MT is mitochondria.
                     continue
 
                 if 'NSAMPLES' in info:

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -216,8 +216,10 @@ class RawDataImporter(DataImporter):
                     if data['mate_chrom'].startswith('GL') or data['mate_chrom'].startswith('MT'):
                         continue
                     if 'MATEID' in info:
-                        data['mate_id'] = info['MATEID']
+                        data['mate_id'] = info.get('MATEID', '')
                     data['variant_id'] = '{}-{}-{}-{}'.format(data['chrom'], data['pos'], data['ref'], alt)
+                    data['allele_count'] = data.get('allele_count', 0)
+                    data['allele_num'] = data.get('allele_num', 0)
 
                     batch += [data]
                     if self.settings.count_calls:

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -199,7 +199,7 @@ class RawDataImporter(DataImporter):
                     continue
 
                 if base["chrom"].startswith('GL') or base["chrom"].startswith('MT'):
-                    # TODO keep this?
+                    # A BND from GL or MT.
                     continue
 
                 if 'NSAMPLES' in info:
@@ -207,21 +207,30 @@ class RawDataImporter(DataImporter):
                     samples = int(info['NSAMPLES'])
 
                 alt_alleles = base['alt'].split(",")
-                # TODO suspect for allelecount or callcount:
-                #    OCC,Number=1,Type=Integer,Description="The number of occurences of the event in the database"
                 for i, alt in enumerate(alt_alleles):
                     data = dict(base)
                     data['allele_freq'] = float(info.get('FRQ'))
                     data['alt'], data['mate_chrom'], data['mate_start'] = re.search('(.+)[[\]](.*?):(\d+)[[\]]', alt).groups()
                     if data['mate_chrom'].startswith('GL') or data['mate_chrom'].startswith('MT'):
+                        # A BND from a chromosome to GL or MT.
+                        # TODO ask a bioinformatician if these cases should be included or not
                         continue
-                    if 'MATEID' in info:
-                        data['mate_id'] = info.get('MATEID', '')
+                    data['mate_id'] = info.get('MATEID', '')
                     data['variant_id'] = '{}-{}-{}-{}'.format(data['chrom'], data['pos'], data['ref'], alt)
                     data['allele_count'] = data.get('allele_count', 0)
                     data['allele_num'] = data.get('allele_num', 0)
-
                     batch += [data]
+                    if self.settings.add_reversed_mates:
+                        # If the vcf only contains one line per breakend, add the reversed version to the database here.
+                        reversed = dict(data)
+                        # TODO Note: in general, ref and alt cannot be assumed to be the same in the reversed direction,
+                        # but our data (so far) only contains N, so we just keep them as is for now.
+                        reversed.update({'mate_chrom': data['chrom'], 'chrom': data['mate_chrom'],
+                                         'mate_start': data['pos'], 'pos': data['mate_start'],
+                                         'chrom_id': data['mate_id'], 'mate_id': data['chrom_id']})
+                        reversed['variant_id'] = '{}-{}-{}-{}'.format(reversed['chrom'], reversed['pos'], reversed['ref'], alt)
+                        # TODO should the `counter` be increased here?
+                        batch += [reversed]
 
                 counter += 1  # count variants (one per vcf row)
 

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -222,9 +222,6 @@ class RawDataImporter(DataImporter):
                     data['allele_num'] = data.get('allele_num', 0)
 
                     batch += [data]
-                    if self.settings.count_calls:
-                        self.get_callcount(data)  # count calls (one per reference)
-                        self.counter['beaconvariants'] += 1  # count variants (one per alternate)
 
                 counter += 1  # count variants (one per vcf row)
 
@@ -493,7 +490,7 @@ class RawDataImporter(DataImporter):
         if self.settings.add_mates:
             self._parse_manta()
             if self.settings.count_calls:
-                self._create_beacon_counts()
+                logging.warning('Do not know how to count calls in the manta file. Skipping this...')
         elif self.settings.variant_file:
             self._insert_variants()
             if self.settings.count_calls:

--- a/scripts/importer/importer.py
+++ b/scripts/importer/importer.py
@@ -100,6 +100,8 @@ if __name__ == '__main__':
                               " the requirements"))
     PARSER.add_argument("--add_mates", action="store_true",
                         help=("Parse MANTA file and add the breakends to the db"))
+    PARSER.add_argument("--add_reversed_mates", action="store_true",
+                        help=("Assume input data only contain one line per BND, covering both directions"))
 
     ARGS = PARSER.parse_args()
 

--- a/sql/beacon_schema.sql
+++ b/sql/beacon_schema.sql
@@ -94,14 +94,14 @@ CREATE OR REPLACE VIEW beacon.beacon_mate_table AS
            dm.pos - 1 AS chromosomeStart,
            dm.chrom_id as chromosomePos,
            dm.mate_chrom as mate,
-           dm.mate_start as mateStart,
+           dm.mate_start - 1 as mateStart,
            dm.mate_id as matePos,
            dm.ref as reference,
            dm.alt as alternate,
            dm.allele_count as alleleCount,
            dm.allele_num as callCount,
            dm.allele_freq as frequency,
-           dm.mate_start as "end",
+           dm.mate_start - 1 as "end",
            'BND' as variantType
      FROM data.mate AS dm
       JOIN beacon.available_datasets as av

--- a/sql/beacon_schema.sql
+++ b/sql/beacon_schema.sql
@@ -91,7 +91,7 @@ CREATE OR REPLACE VIEW beacon.beacon_mate_table AS
                           d.short_name,
                           av.dataset_version) AS datasetId,
            substr(dm.chrom, 1, 2) AS chromosome,
-           dm.pos - 1 AS "chromosomeStart",
+           dm.pos - 1 AS chromosomeStart,
            dm.chrom_id as chromosomePos,
            dm.mate_chrom as mate,
            dm.mate_start as mateStart,


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change

### Pull request long description:
Small fixes to the sql model and the import script for breakends.
Also adds the `--add_reversed_mates` flag to the importer, to make a BND searchable in the beacon by using any of its two chromosome as the "main" one.


### Changes made:
1. Set default values for 0 `allele_num` (`callCount`) and `allele_count` (`variantCount`). '' for `mate_id`.
2. Skip counting calls when importing mates, even when asked to, since we don't know what to do with these numbers anyway (the dataset usually already has that info stored in the db).
3. `"chromosomeStart"` => `chromosomeStart` (don't enforce capital `s`)
4. Add option `--add_reversed_mates` to importer. Adds one extra row to the db for each BND, representing the same breakend but with its mate encoded as the starting chromosme.

### Question:
Should a "loop" like this

`1	54720	cluster_216	N	N[1:54720[`

be kept once or twice in the db?

```
| chromosome | chromosomestart | chromosomepos | mate | matestart |   matepos   | 
-+------------+-----------------+---------------+------+-----------+-------------+
 | 1          |           54719 | cluster_216   | 1    |     54719 |             |
 | 1          |           54719 |               | 1    |     54719 | cluster_216 |
```