### PR TITLE
Allow extraction of rsids even if some values in the field are not rsids

### DIFF
--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -325,9 +325,8 @@ class RawDataImporter(DataImporter):
                         annotations = [dict(zip(vep_field_names, x.split('|'))) for x in consequence_array if len(vep_field_names) == len(x.split('|'))]
 
                     alt_alleles = base['alt'].split(",")
-                    if base['rsid'].startswith('rs'):
-                        rsids = [int(rsid.strip('rs')) for rsid in base['rsid'].split(';')]
-                    else:
+                    rsids = [int(rsid.strip('rs')) for rsid in base['rsid'].split(';') if rsid.startswith('rs')]
+                    if not rsids:
                         rsids = [None]
 
                     try:


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [X] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
After adding rsids using gatk, ACPop has values in the format `1:3195;rs6421780` in  the rsid column. Instead of checking whether the first value starts with `rs`, it will now check all values in the column for `rs` and check whether any were found.