### PR TITLE
Test both 3.6 and 3.7 on bionic in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
-python:
-    - "3.6"
+matrix:
+    include:
+        - python: 3.6
+          dist: bionic
+        - python: 3.7
+          dist: bionic
 services:
     - docker
 before_install:


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [ ] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [X] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Make Travis test code in both python 3.6 and 3.7 as well as use Bionic (18.04) instead of Trusty (14.04).
