### PR TITLE
Add bioschema for beacon

### DIFF
--- a/backend/application.py
+++ b/backend/application.py
@@ -63,12 +63,14 @@ class GetSchema(handlers.UnsafeHandler):
     def get(self):
         dataset = None
         version = None
+        beacon = None
         try:
             url = self.get_argument('url')
             match = re.match(".*/dataset/([^/]+)(/version/([^/]+))?", url)
             if match:
                 dataset = match.group(1)
                 version = match.group(3)
+            beacon = re.match(".*/dataset/.*/beacon", url)
         except tornado.web.MissingArgumentError:
             pass
 
@@ -125,6 +127,21 @@ class GetSchema(handlers.UnsafeHandler):
                 logging.error("Dataset version does not exist: {}".format(e))
             except db.DatasetVersionCurrent.DoesNotExist as e:
                 logging.error("Dataset does not exist: {}".format(e))
+
+        if beacon:
+            base = {"@context": "http://schema.org",
+                    "@id": "https://swefreq.nbis.se/api/beacon-elixir/",  # or maybe "se.nbis.swefreq" as in the beacon api?
+                    "@type": "Beacon",
+                    "dataset": [dataset_schema],
+                    "dct:conformsTo": "https://bioschemas.org/specifications/drafts/Beacon/",
+                    "name": "Swefreq Beacon",
+                    "provider": base["provider"],
+                    "supportedRefs": ["GRCh37"],
+                    "description": "Beacon API Web Server based on the GA4GH Beacon API",
+                    "version": "1.1.0",  # beacon api version
+                    "aggregator": False,
+                    "url": "https://swefreq.nbis.se/api/beacon-elixir/"
+                   }
 
         self.finish(base)
 


### PR DESCRIPTION
<!-- REMOVE SECTIONS THAT ARE NOT APPLICABLE, DON'T OVERTHINK IT -->

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Functional change
- [X] New feature

### Pull request long description:
Add a bioschema object describing the beacon. This will be given for urls ending with `/beacon`, changing the response for https://swefreq.nbis.se/api/schema?url=https://swefreq.nbis.se/dataset/SweGen/beacon
to type `Beacon` instead of `DataCatalog`.

See https://bioschemas.org/specifications/drafts/Beacon/.



