### PR TITLE
BND code cleanup

### DIFF
--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -257,16 +257,14 @@ class RawDataImporter(DataImporter):
                                                                             reversed_mates['pos'],
                                                                             reversed_mates['ref'],
                                                                             alt)
-                        # increase the counter; reversed BNDs are usually kept at their own vcf row
-                        counter += 1
                         batch += [reversed_mates]
 
-                counter += 1  # count variants (one per vcf row)
+                # count variants (one per vcf row)
+                counter += 1
 
                 if len(batch) >= self.settings.batch_size:
                     if not self.settings.dry_run:
                         db.VariantMate.insert_many(batch).execute()
-
                     batch = []
 
                     # Update progress

--- a/scripts/importer/data_importer/raw_data_importer.py
+++ b/scripts/importer/data_importer/raw_data_importer.py
@@ -270,7 +270,7 @@ class RawDataImporter(DataImporter):
 
                     batch = []
                     # Update progress
-                    if not self.counter['variants']:
+                    if self.counter['variants']:
                         last_progress = self._update_progress_bar(counter,
                                                                   self.counter['variants'],
                                                                   last_progress)
@@ -278,7 +278,7 @@ class RawDataImporter(DataImporter):
         if batch and not self.settings.dry_run:
             db.VariantMate.insert_many(batch).execute()
 
-        if not self.counter['variants']:
+        if self.counter['variants']:
             last_progress = self._update_progress_bar(counter,
                                                       self.counter['variants'],
                                                       last_progress,


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [X] Functional change
- [X] Code cleanup

### Pull request long description:
Clean up of the code for parsing manta files / adding structural variants / breakends. Includes both plain refactoring and functional changes.


### Changes made:
Functional changes:

1.  14c498c Assumption: the manta files should always add data to an existing dataset, and should therefore never add / change counts for the whole dataset. The code doing this is removed, to avoid unintended changes of the dataset counts.

2.  d1f783b The `counter` now counts: +1 for every row. This information is only used for logging and the progress bar, due to the commit above. No extra counting of reversed mates is done, since `count_entries` does not count these.

Bug fix:

3. be0458c Bug fix: remove `not` so that the progress bar can be updated.

Code cleanup:

4. 1cf6470 Improve comments etc.

5. 69d9f01  Make the function `parse_manta` less long by breaking out parts into its own function.

6. 1e698c5, 5521dd6 Break out various code from `parse_manta`.



### TODOs

Look at separation between functions and methods (eg `parse_info` vs `parse_baseinfo`).