### PR TITLE
Fix bad f-string when downloading file

### DIFF
--- a/backend/modules/browser/browser_handlers.py
+++ b/backend/modules/browser/browser_handlers.py
@@ -55,7 +55,7 @@ class Download(handlers.UnsafeHandler):
         filename = f'{dataset}_{datatype}_{item}.csv'
         self.set_header('Content-Type', 'text/csv')
         self.set_header(f'content-Disposition',
-                        f'attachement; filename={filename}')
+                        f'attachment; filename={filename}')
 
         data = utils.get_variant_list(dataset, datatype, item, ds_version)
         # filter variants based on what is shown

--- a/backend/modules/browser/browser_handlers.py
+++ b/backend/modules/browser/browser_handlers.py
@@ -52,9 +52,10 @@ class Download(handlers.UnsafeHandler):
         """
         # ctrl.filterVariantsBy~ctrl.filterIncludeNonPass
         dataset, ds_version = utils.parse_dataset(dataset, ds_version)
+        filename = f'{dataset}_{datatype}_{item}.csv'
         self.set_header('Content-Type', 'text/csv')
         self.set_header(f'content-Disposition',
-                        'attachement; filename={f"{dataset}_{datatype}_{item}.csv"}')
+                        f'attachement; filename={filename}')
 
         data = utils.get_variant_list(dataset, datatype, item, ds_version)
         # filter variants based on what is shown

--- a/backend/modules/browser/tests/test_browser_handlers.py
+++ b/backend/modules/browser/tests/test_browser_handlers.py
@@ -33,19 +33,22 @@ def test_download():
     response = requests.get('{}/api/dataset/{}/browser/download/{}/{}'.format(BASE_URL, dataset, data_type, data_item))
     assert len(response.text.split('\n')) == 180  # header + 178 + \n
     response = requests.get('{}/api/dataset/{}/browser/download/{}/{}/filter/all~false'.format(BASE_URL, dataset, data_type, data_item))
-    import logging
-    logging.error(response.text.split('\n'))
     assert len(response.text.split('\n')) == 8
     response = requests.get('{}/api/dataset/{}/browser/download/{}/{}/filter/all~true'.format(BASE_URL, dataset, data_type, data_item))
     assert len(response.text.split('\n')) == 180
     response = requests.get('{}/api/dataset/{}/browser/download/{}/{}/filter/mislof~true'.format(BASE_URL, dataset, data_type, data_item))
     assert len(response.text.split('\n')) == 2
+    filename = f'{dataset}_{data_type}_{data_item}.csv'
+    assert response.headers['content-disposition'] == f'attachment; filename={filename}'
+
     data_type = 'region'
     data_item = '22-29450622-29465622'
     response = requests.get('{}/api/dataset/{}/browser/download/{}/{}/filter/mislof~false'.format(BASE_URL, dataset, data_type, data_item))
     assert len(response.text.split('\n')) == 3
     response = requests.get('{}/api/dataset/{}/browser/download/{}/{}/filter/lof~false'.format(BASE_URL, dataset, data_type, data_item))
     assert len(response.text.split('\n')) == 3
+    filename = f'{dataset}_{data_type}_{data_item}.csv'
+    assert response.headers['content-disposition'] == f'attachment; filename={filename}'
 
 
 def test_get_coverage():


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
The f-string for the filename when downloading variants from the browser was done incorrectly.