### PR TITLE
Remove space that messed up Elixir auth.

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -114,7 +114,7 @@ class ElixirLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
         client_id = self.settings['elixir_oauth']['id']
         secret = self.settings['elixir_oauth']['secret']
 
-        authorization = base64.b64encode(bytes(f"{client_id}: {secret}", 'ascii')).decode('ascii')
+        authorization = base64.b64encode(bytes(f"{client_id}:{secret}", 'ascii')).decode('ascii')
 
         response = await http.fetch(self._OAUTH_ACCESS_TOKEN_URL,
                                     method="POST",


### PR DESCRIPTION
<!-- REMOVE SECTIONS THAT ARE NOT APPLICABLE, DON'T OVERTHINK IT -->

<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read the "Contributing" section of the README and also the notes in CodingStyle. -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Remove a space that messed up the base64 string used to handle auth.
