### PR TITLE
Fix file sizes; K->k, b->B

### DIFF
--- a/backend/application.py
+++ b/backend/application.py
@@ -271,7 +271,7 @@ class DatasetFiles(handlers.AuthorizedHandler):
 
 
 def format_bytes(nbytes):
-    postfixes = ['b', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb']
+    postfixes = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB']
     exponent = math.floor(math.log(nbytes) / math.log(1000))
     return f"{round(nbytes/1000**exponent, 2)} {postfixes[exponent]}"
 


### PR DESCRIPTION

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Fix file sizes. Currently they are `b`, `Kb`, `Mb` etc. Changed to `B`, `kB`, `MB`...