### PR TITLE
Fix useless error message for rsids

### DIFF
--- a/backend/modules/browser/lookups.py
+++ b/backend/modules/browser/lookups.py
@@ -520,13 +520,13 @@ def get_variants_by_rsid(dataset: str, rsid: str, ds_version: str = None) -> lis
         raise error.NotFoundError(f'Unable to find the dataset version in the database')
 
     if not rsid.startswith('rs'):
-        logging.error('get_variants_by_rsid({dataset}, {rsid}): rsid not starting with rs')
+        logging.warning(f'get_variants_by_rsid({dataset}, {rsid}): rsid not starting with rs')
         raise error.ParsingError('rsid not starting with rs')
 
     try:
         int_rsid = int(rsid.lstrip('rs'))
     except ValueError as err:
-        logging.error('get_variants_by_rsid({}, {}): not an integer after rs'.format(dataset, rsid))
+        logging.warning(f'get_variants_by_rsid({}, {}): not an integer after rs'.format(dataset, rsid))
         raise error.ParsingError('Not an integer after rs') from err
 
     variants = (db.Variant

--- a/backend/modules/browser/lookups.py
+++ b/backend/modules/browser/lookups.py
@@ -526,7 +526,7 @@ def get_variants_by_rsid(dataset: str, rsid: str, ds_version: str = None) -> lis
     try:
         int_rsid = int(rsid.lstrip('rs'))
     except ValueError as err:
-        logging.warning(f'get_variants_by_rsid({}, {}): not an integer after rs'.format(dataset, rsid))
+        logging.warning(f'get_variants_by_rsid({dataset}, {rsid}): not an integer after rs')
         raise error.ParsingError('Not an integer after rs') from err
 
     variants = (db.Variant


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
A missing f-marker messed up the error reporting for bad rsids.
Also decrease severity to `warning` instead of `error`.