### PR TITLE
Fix the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,15 @@
 language: python
-matrix:
-    include:
-        - python: 3.6
-          dist: bionic
-        - python: 3.7
-          dist: bionic
+python:
+ - "3.6"
+ - "3.7"
+ - "3.8"
 services:
-    - docker
-before_install:
-    - test/travis_before_install.sh
+  - postgresql
 install:
     - pip install -r backend/requirements.txt
     - pip install -r test/requirements.txt
     - pip install -r scripts/importer/requirements.txt
-    - pip install coverage coveralls
-    - pip install pylint
 script:
     - test/travis_script.sh
 addons:
   postgresql: "10"
-  apt:
-    packages:
-    - postgresql-client-10

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,1 +1,3 @@
 pytest-cov
+coveralls
+pylint

--- a/test/travis_before_install.sh
+++ b/test/travis_before_install.sh
@@ -1,8 +1,0 @@
-#!/bin/sh -x
-
-PSQL_VERSION="10"
-PSQL_PORT="5433"
-
-docker pull "postgres:$PSQL_VERSION"
-
-docker run --rm -e "POSTGRES_DB=swefreq" -d -p "$PSQL_PORT:5432" "postgres:$PSQL_VERSION"


### PR DESCRIPTION
### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [X] Bug fix
- [ ] Functional change
- [ ] New feature
- [ ] Code cleanup
- [X] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:
Changes in travis made postgres not start on the expected port.

Postgres 10 is now started on the default port (5432) without using docker. The travis script is updated to use the default port.

The  build is now tested on Python 3.6, 3.7, and 3.8. The config is done using the standard way in travis instead of defining image and version in a matrix.

Move the installation of `coveralls` and `pylint` to `test/requirements.txt`. 