### PR TITLE
Update auth to use LifeScience AAI instead of Elixir AAI

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -32,9 +32,9 @@ class DeveloperLogoutHandler(BaseHandler):
 
 
 class ElixirLoginHandler(BaseHandler, tornado.auth.OAuth2Mixin):
-    _OAUTH_AUTHORIZE_URL = "https://login.elixir-czech.org/oidc/authorize"
-    _OAUTH_ACCESS_TOKEN_URL = "https://login.elixir-czech.org/oidc/token"
-    _OAUTH_USERINFO_ENDPOINT = "https://login.elixir-czech.org/oidc/userinfo"
+    _OAUTH_AUTHORIZE_URL = "https://login.aai.lifescience-ri.eu/oidc/authorize"
+    _OAUTH_ACCESS_TOKEN_URL = "https://login.aai.lifescience-ri.eu/oidc/token"
+    _OAUTH_USERINFO_ENDPOINT = "https://login.aai.lifescience-ri.eu/oidc/userinfo"
     _OAUTH_SETTINGS_KEY = 'elixir_oauth'
 
     def _generate_state(self):


### PR DESCRIPTION
### Describe the pull request:
- [ ] Bug fix
- [x] Functional change
- [ ] New feature
- [ ] Code cleanup
- [ ] Build system change
- [ ] Documentation change
- [ ] Language translation

### Pull request long description:

Elixir AAI has been migrated to LifeScience AAI, so we need to update some endpoints in the code.


### Changes made:

Updated variables that specify the URLs to the AAI

### Related issues:


### Additional information:
The database need to be updated as well, the following SQL statement should do the trick:

```sql
UPDATE users.users SET identity=substring(identity, 1, 40) || '@lifescience-ri.eu' WHERE identity_type='elixir;
```

### Release note:
Update auth to use LifeScience AAI instead of Elixir AAI.